### PR TITLE
Update Java version from 11 to 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM gradle:8.8-jdk11-jammy AS build
+FROM --platform=$BUILDPLATFORM gradle:8.8-jdk17-jammy AS build
 
 COPY --chown=gradle:gradle . /home/gradle/
 WORKDIR /home/gradle/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,7 +103,7 @@ tasks {
 
 application { mainClass.set("it.smartphonecombo.uecapabilityparser.cli.Main") }
 
-kotlin { jvmToolchain(11) }
+kotlin { jvmToolchain(17) }
 
 spotless {
     format("misc") {


### PR DESCRIPTION
This PR updates the Java version from 11 to 17 in both the build.gradle.kts file and the Dockerfile.

This change is necessary to build the application with the latest Java version and to create a Docker image that includes the uecapabilityparser-web submodule.

After merging this PR, you can build the Docker image with the following command:

```bash
docker build -t ghcr.io/high3eam/uecapabilityparser:latest .
docker push ghcr.io/high3eam/uecapabilityparser:latest
```