### PR TITLE
Add GitHub Actions workflow for Docker build and push to GHCR

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,49 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/high3eam/uecapabilityparser
+          tags: |
+            type=raw,value=latest
+            type=sha,format=short
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,10 @@ RUN gradle build --no-daemon -x check
 
 FROM eclipse-temurin:21-jre-noble AS deploy
 
+LABEL org.opencontainers.image.source=https://github.com/high3eam/uecapabilityparser
+LABEL org.opencontainers.image.description="UE Capability parser with NR RRC combo support"
+LABEL org.opencontainers.image.licenses=MIT
+
 ARG SCAT_TAG=90be06a
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to build and push the Docker image to GitHub Container Registry (GHCR).

Changes:
- Added a GitHub Actions workflow file that builds and pushes the Docker image to GHCR on every push to the main branch
- Added metadata labels to the Dockerfile for better container information

After merging this PR, the GitHub Actions workflow will automatically build and push the Docker image to GHCR whenever changes are pushed to the main branch. The image will be available at `ghcr.io/high3eam/uecapabilityparser:latest`.